### PR TITLE
🔧update: actions/checkout to v6.0.3 and resolve package paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Assert bot detection script behavior
         shell: bash
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 
@@ -132,7 +132,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 
@@ -204,7 +204,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,85 @@ jobs:
           run_case "warengonzaga" "true" "false" ""
           run_case "dependabot[bot]" "false" "false" ""
 
+  package-path-resolution:
+    name: Package Path Resolution
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Prepare local action copy and consumer fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p local-action
+          rsync -a --exclude '.git' --exclude 'local-action' ./ ./local-action/
+
+          cat > package.json <<'EOF'
+          {
+           "name": "@wgtechlabs/path-resolution-fixture",
+           "version": "0.1.0",
+           "scripts": {
+             "build": "echo path-resolution-build",
+             "test": "echo path-resolution-test"
+           }
+          }
+          EOF
+
+      - name: Run action from nested action path
+        id: nested-action
+        uses: ./local-action
+        with:
+          package-manager: npm
+          registry: github
+          github-token: ${{ github.token }}
+          publish-enabled: 'false'
+          audit-enabled: 'false'
+          pr-comment-enabled: 'false'
+
+      - name: Assert checkout-required resolver detection
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          run_resolver() {
+            local pkg_path="$1"
+            local pkg_paths="${2:-}"
+            local out
+            out=$(mktemp)
+            PACKAGE_PATH="$pkg_path" PACKAGE_PATHS="$pkg_paths" \
+              GITHUB_WORKSPACE="$GITHUB_WORKSPACE" GITHUB_OUTPUT="$out" \
+              bash ./scripts/resolve-package-paths.sh > /dev/null
+            grep '^checkout-required=' "$out" | cut -d= -f2
+            rm -f "$out"
+          }
+
+          # relative path to missing file → checkout required
+          test "$(run_resolver "./nonexistent-package.json")" = "true"
+
+          # absolute path under GITHUB_WORKSPACE to missing file → checkout required
+          test "$(run_resolver "$GITHUB_WORKSPACE/nonexistent-package.json")" = "true"
+
+          # absolute path outside GITHUB_WORKSPACE → checkout not required
+          test "$(run_resolver "/tmp/nonexistent-package.json")" = "false"
+
+          # existing file (relative) → checkout not required
+          test "$(run_resolver "./package.json")" = "false"
+
+      - name: Assert nested action outputs
+        shell: bash
+        run: |
+          test "${{ steps.nested-action.outputs.build-skipped }}" = "false"
+          test -n "${{ steps.nested-action.outputs.package-version }}"
+          test "${{ steps.nested-action.outputs.github-published }}" = "false"
+
   single-package-bun:
     name: Single Package Bun
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Tag: patch
 
 | Input | Description | Default | Required |
 |-------|-------------|---------|----------|
-| `package-path` | Path to package.json | `./package.json` | No |
+| `package-path` | Path to package.json. Relative paths are resolved from the workflow workspace, and repository contents are checked out automatically when needed. | `./package.json` | No |
 | `build-script` | NPM script to run before publishing | `build` | No |
 | `package-manager` | Package manager to use: `npm`, `yarn`, `pnpm`, `bun`, or `auto` (auto-detects from lockfile) | `auto` | No |
 | `version-prefix` | Accepted for backward compatibility but ignored at runtime because npm package versions must remain valid SemVer | - | No |
@@ -222,8 +222,8 @@ Tag: patch
 | Input | Description | Default | Required |
 |-------|-------------|---------|----------|
 | `monorepo` | Enable monorepo mode | `false` | No |
-| `package-paths` | Comma-separated list of package.json paths (monorepo mode only). Takes priority over workspace-detection. Either this OR workspace-detection with valid workspaces field is required when monorepo is true. | - | Conditional* |
-| `workspace-detection` | Auto-detect workspaces from the package.json resolved from `package-path` (default `./package.json`). Reads its `workspaces` field and discovers all non-private packages. | `true` | No |
+| `package-paths` | Comma-separated list of package.json paths (monorepo mode only). Relative paths are resolved from the workflow workspace. Takes priority over workspace-detection. Either this OR workspace-detection with valid workspaces field is required when monorepo is true. | - | Conditional* |
+| `workspace-detection` | Auto-detect workspaces from the package.json resolved from `package-path` (default `./package.json`). The root package path is resolved from the workflow workspace. Reads its `workspaces` field and discovers all non-private packages. | `true` | No |
 | `changed-only` | Only build/publish packages that changed relative to the event-specific git diff base (monorepo mode only). Uses git diff to detect changes. | `true` | No |
 | `dependency-order` | Build packages in dependency order using topological sort (monorepo mode only). Analyzes workspace dependencies and builds packages in the correct order. Works with Bun-only monorepos through the same runtime-aware helper execution used elsewhere in the action. Set to `false` to use discovery order. Has no effect when using explicit `package-paths` without workspace discovery metadata. | `true` | No |
 

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ inputs:
   
   # Package Configuration
   package-path:
-    description: 'Path to package.json'
+    description: 'Path to package.json. Relative paths are resolved from the workflow workspace, and repository contents are checked out automatically when needed.'
     required: false
     default: './package.json'
   
@@ -113,7 +113,7 @@ inputs:
     default: 'false'
   
   package-paths:
-    description: 'Comma-separated list of package.json paths (monorepo mode)'
+    description: 'Comma-separated list of package.json paths (monorepo mode). Relative paths are resolved from the workflow workspace.'
     required: false
     default: ''
   
@@ -294,6 +294,23 @@ runs:
         BUILD_SKIP_TYPES: ${{ inputs.build-skip-types }}
         PR_TITLE: ${{ github.event.pull_request.title }}
 
+    - name: Resolve Package Paths
+      id: resolve-paths
+      if: steps.commit-gate.outputs.should-build != 'false'
+      shell: bash
+      run: |
+        bash ${{ github.action_path }}/scripts/resolve-package-paths.sh
+      env:
+        PACKAGE_PATH: ${{ inputs.package-path }}
+        PACKAGE_PATHS: ${{ inputs.package-paths }}
+
+    - name: Checkout Repository Contents
+      if: steps.commit-gate.outputs.should-build != 'false' && steps.resolve-paths.outputs.checkout-required == 'true'
+      uses: actions/checkout@v6.0.3
+      with:
+        fetch-depth: 0
+        token: ${{ inputs.github-token }}
+
     # =============================================================================
     # MONOREPO MODE
     # =============================================================================
@@ -309,8 +326,8 @@ runs:
         GITHUB_CONTEXT: ${{ toJson(github) }}
         MAIN_BRANCH: ${{ inputs.main-branch }}
         DEV_BRANCH: ${{ inputs.dev-branch }}
-        PACKAGE_PATH: ${{ inputs.package-path }}
-        PACKAGE_PATHS: ${{ inputs.package-paths }}
+        PACKAGE_PATH: ${{ steps.resolve-paths.outputs.package-path }}
+        PACKAGE_PATHS: ${{ steps.resolve-paths.outputs.package-paths }}
         WORKSPACE_DETECTION: ${{ inputs.workspace-detection }}
         CHANGED_ONLY: ${{ inputs.changed-only }}
         DEPENDENCY_ORDER: ${{ inputs.dependency-order }}
@@ -381,7 +398,7 @@ runs:
         GITHUB_CONTEXT: ${{ toJson(github) }}
         MAIN_BRANCH: ${{ inputs.main-branch }}
         DEV_BRANCH: ${{ inputs.dev-branch }}
-        PACKAGE_PATH: ${{ inputs.package-path }}
+        PACKAGE_PATH: ${{ steps.resolve-paths.outputs.package-path }}
         VERSION_PREFIX: ${{ inputs.version-prefix }}
     
     - name: Configure Registries
@@ -397,7 +414,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         GITHUB_REGISTRY_URL: ${{ inputs.github-registry-url }}
         PACKAGE_SCOPE: ${{ inputs.package-scope }}
-        PACKAGE_PATH: ${{ inputs.package-path }}
+        PACKAGE_PATH: ${{ steps.resolve-paths.outputs.package-path }}
         GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
     
     - name: Build and Publish Package
@@ -410,7 +427,7 @@ runs:
         REGISTRY: ${{ inputs.registry }}
         PACKAGE_VERSION: ${{ steps.detect-flow.outputs.version }}
         NPM_TAG: ${{ steps.detect-flow.outputs.npm-tag }}
-        PACKAGE_PATH: ${{ inputs.package-path }}
+        PACKAGE_PATH: ${{ steps.resolve-paths.outputs.package-path }}
         BUILD_SCRIPT: ${{ inputs.build-script }}
         PACKAGE_MANAGER: ${{ inputs.package-manager }}
         PUBLISH_ENABLED: ${{ inputs.publish-enabled }}
@@ -431,7 +448,7 @@ runs:
       env:
         AUDIT_LEVEL: ${{ inputs.audit-level }}
         FAIL_ON_AUDIT: ${{ inputs.fail-on-audit }}
-        PACKAGE_PATH: ${{ inputs.package-path }}
+        PACKAGE_PATH: ${{ steps.resolve-paths.outputs.package-path }}
         PACKAGE_MANAGER: ${{ inputs.package-manager }}
     
     - name: Generate Outputs
@@ -442,7 +459,7 @@ runs:
         bash ${{ github.action_path }}/scripts/generate-outputs.sh
       env:
         PACKAGE_VERSION: ${{ steps.detect-flow.outputs.version }}
-        PACKAGE_PATH: ${{ inputs.package-path }}
+        PACKAGE_PATH: ${{ steps.resolve-paths.outputs.package-path }}
         REGISTRY: ${{ inputs.registry }}
         NPM_REGISTRY_URL: ${{ inputs.npm-registry-url }}
         GITHUB_REGISTRY_URL: ${{ inputs.github-registry-url }}
@@ -462,7 +479,7 @@ runs:
         BUILD_FLOW_TYPE: ${{ steps.detect-flow.outputs.build-flow-type }}
         PACKAGE_VERSION: ${{ steps.detect-flow.outputs.version }}
         NPM_TAG: ${{ steps.detect-flow.outputs.npm-tag }}
-        PACKAGE_PATH: ${{ inputs.package-path }}
+        PACKAGE_PATH: ${{ steps.resolve-paths.outputs.package-path }}
         REGISTRY: ${{ inputs.registry }}
         NPM_REGISTRY_URL: ${{ inputs.npm-registry-url }}
         GITHUB_REGISTRY_URL: ${{ inputs.github-registry-url }}

--- a/scripts/resolve-package-paths.sh
+++ b/scripts/resolve-package-paths.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -e
+
+echo "🧭 Resolving package paths..."
+
+WORKSPACE_ROOT="${GITHUB_WORKSPACE:-$PWD}"
+PACKAGE_PATH_INPUT="${PACKAGE_PATH:-./package.json}"
+PACKAGE_PATHS_INPUT="${PACKAGE_PATHS:-}"
+CHECKOUT_REQUIRED="false"
+
+resolve_path() {
+  local input_path="$1"
+
+  if [ -z "$input_path" ]; then
+    return 0
+  fi
+
+  if [[ "$input_path" = /* ]]; then
+    printf '%s\n' "$input_path"
+  else
+    input_path="${input_path#./}"
+    printf '%s/%s\n' "$WORKSPACE_ROOT" "$input_path"
+  fi
+}
+
+RESOLVED_PACKAGE_PATH="$(resolve_path "$PACKAGE_PATH_INPUT")"
+
+if [[ "$RESOLVED_PACKAGE_PATH" == "$WORKSPACE_ROOT"/* ]] && [ ! -f "$RESOLVED_PACKAGE_PATH" ]; then
+  CHECKOUT_REQUIRED="true"
+fi
+
+RESOLVED_PACKAGE_PATHS=""
+
+if [ -n "$PACKAGE_PATHS_INPUT" ]; then
+  declare -a RESOLVED_PATH_ARRAY=()
+
+  IFS=',' read -ra PACKAGE_PATH_ARRAY <<< "$PACKAGE_PATHS_INPUT"
+  for raw_path in "${PACKAGE_PATH_ARRAY[@]}"; do
+    trimmed_path="${raw_path#"${raw_path%%[![:space:]]*}"}"
+    trimmed_path="${trimmed_path%"${trimmed_path##*[![:space:]]}"}"
+
+    if [ -z "$trimmed_path" ]; then
+      continue
+    fi
+
+    resolved_path="$(resolve_path "$trimmed_path")"
+    RESOLVED_PATH_ARRAY+=("$resolved_path")
+
+    if [[ "$resolved_path" == "$WORKSPACE_ROOT"/* ]] && [ ! -f "$resolved_path" ]; then
+      CHECKOUT_REQUIRED="true"
+    fi
+  done
+
+  if [ "${#RESOLVED_PATH_ARRAY[@]}" -gt 0 ]; then
+    RESOLVED_PACKAGE_PATHS="$(IFS=,; echo "${RESOLVED_PATH_ARRAY[*]}")"
+  fi
+fi
+
+echo "📍 Workspace root: $WORKSPACE_ROOT"
+echo "📄 Resolved package-path: $RESOLVED_PACKAGE_PATH"
+
+if [ -n "$RESOLVED_PACKAGE_PATHS" ]; then
+  echo "📚 Resolved package-paths: $RESOLVED_PACKAGE_PATHS"
+fi
+
+if [ "$CHECKOUT_REQUIRED" = "true" ]; then
+  echo "📥 Repository contents are not present yet; checkout will be requested"
+fi
+
+echo "workspace-root=$WORKSPACE_ROOT" >> "$GITHUB_OUTPUT"
+echo "package-path=$RESOLVED_PACKAGE_PATH" >> "$GITHUB_OUTPUT"
+echo "package-paths=$RESOLVED_PACKAGE_PATHS" >> "$GITHUB_OUTPUT"
+echo "checkout-required=$CHECKOUT_REQUIRED" >> "$GITHUB_OUTPUT"

--- a/scripts/resolve-package-paths.sh
+++ b/scripts/resolve-package-paths.sh
@@ -8,19 +8,47 @@ PACKAGE_PATH_INPUT="${PACKAGE_PATH:-./package.json}"
 PACKAGE_PATHS_INPUT="${PACKAGE_PATHS:-}"
 CHECKOUT_REQUIRED="false"
 
+normalize_path() {
+  local absolute_path="$1"
+  local -a path_stack=()
+  local IFS='/'
+  read -ra path_parts <<< "$absolute_path"
+
+  for part in "${path_parts[@]}"; do
+    case "$part" in
+      ''|'.')
+        continue
+        ;;
+      '..')
+        if [ "${#path_stack[@]}" -gt 0 ]; then
+          unset 'path_stack[${#path_stack[@]}-1]'
+        fi
+        ;;
+      *)
+        path_stack+=("$part")
+        ;;
+    esac
+  done
+
+  printf '/%s\n' "$(IFS=/; echo "${path_stack[*]}")"
+}
+
 resolve_path() {
   local input_path="$1"
+  local candidate_path
 
   if [ -z "$input_path" ]; then
     return 0
   fi
 
   if [[ "$input_path" = /* ]]; then
-    printf '%s\n' "$input_path"
+    candidate_path="$input_path"
   else
     input_path="${input_path#./}"
-    printf '%s/%s\n' "$WORKSPACE_ROOT" "$input_path"
+    candidate_path="$WORKSPACE_ROOT/$input_path"
   fi
+
+  normalize_path "$candidate_path"
 }
 
 RESOLVED_PACKAGE_PATH="$(resolve_path "$PACKAGE_PATH_INPUT")"


### PR DESCRIPTION
This pull request introduces robust and automatic resolution of `package-path` and `package-paths` inputs in the GitHub Action, ensuring that relative paths are always resolved from the workflow workspace and that repository contents are checked out only when necessary. This change improves reliability and user experience, especially for monorepo and custom directory setups. Documentation and input descriptions have also been updated to clarify this behavior.

**Key changes:**

### Core functionality and workflow logic

* Added a new script `scripts/resolve-package-paths.sh` that resolves `package-path` and `package-paths` to absolute paths, determines if a repository checkout is needed, and outputs these values for use in subsequent workflow steps.
* Updated `action.yml` to use the resolved package paths from the new script, and to conditionally perform a repository checkout only if required, preventing unnecessary checkouts and improving efficiency. All downstream steps now consume the resolved paths. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R297-R313) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L312-R330) [[3]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L384-R401) [[4]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L400-R417) [[5]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L413-R430) [[6]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L434-R451) [[7]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L445-R462) [[8]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L465-R482)

### Documentation and input clarity

* Enhanced descriptions for `package-path` and `package-paths` in `action.yml` and the `README.md` to clarify that relative paths are resolved from the workflow workspace and that automatic checkout occurs as needed. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L48-R48) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L116-R116) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L177-R177) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L225-R226)

### CI and workflow improvements

* Added a new `package-path-resolution` job to `.github/workflows/ci.yml` to test the new path resolution logic, including edge cases for missing and existing files, and to validate correct checkout behavior.
* Updated all workflow jobs to use the latest `actions/checkout@v6.0.3` for consistency and security. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL21-R21) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL135-R214) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL207-R286) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L22-R22)